### PR TITLE
Allow to use extra query parameters

### DIFF
--- a/src/Api/BaseApi.php
+++ b/src/Api/BaseApi.php
@@ -40,9 +40,15 @@ class BaseApi
         return $response[static::API_KEY];
     }
 
-    public function create(array $data)
+    /**
+     * @param array $data
+     * @param array $params
+     *
+     * @return array
+     */
+    public function create(array $data, array $params = [])
     {
-        $response = $this->client->post(static::API_URL, $this->organizationId, $data);
+        $response = $this->client->post(static::API_URL, $this->organizationId, $data, $params);
 
         return $response[static::API_KEY];
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -33,29 +33,54 @@ class Client
         );
     }
 
-    public function get($url, $organizationId, $id)
+    /**
+     * @param string $url
+     * @param string $organizationId
+     * @param string $id
+     * @param array $params Additional query params
+     *
+     * @return array
+     */
+    public function get($url, $organizationId, $id, array $params = [])
     {
         return $this->processResult(
-            $this->httpClient->get($url.'/'.$id, ['query' => $this->getParams($organizationId)])
+            $this->httpClient->get($url.'/'.$id, ['query' => $this->getParams($organizationId) + $params])
         );
     }
 
-    public function post($url, $organizationId, $data = [])
+    /**
+     * @param string $url
+     * @param string $organizationId
+     * @param array $data
+     * @param array $params Additional query params
+     *
+     * @return array
+     */
+    public function post($url, $organizationId, array $data = [], array $params = [])
     {
         return $this->processResult($this->httpClient->post(
             $url,
             [
-                'query' => $this->getParams($organizationId, $data),
+                'query' => $this->getParams($organizationId, $data) + $params,
             ]
         ));
     }
 
-    public function put($url, $organizationId, $id, $data)
+    /**
+     * @param string $url
+     * @param string $organizationId
+     * @param mixed $id
+     * @param array $data
+     * @param array $params Additional query params
+     *
+     * @return array
+     */
+    public function put($url, $organizationId, $id, array $data = [], array $params = [])
     {
         return $this->processResult($this->httpClient->put(
             $url.'/'.$id,
             [
-                'query' => $this->getParams($organizationId, $data),
+                'query' => $this->getParams($organizationId, $data) + $params,
             ]
         ));
     }


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |yes   |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

Allow to pass extra query string parameters to request, in order to use some features that requires additional arguments (exposed as "Parameters" at ZohoBooks API v3 docs).
[Example](https://www.zoho.com/books/api/v3/invoices/#get-an-invoice):
**Parameters**

|Name  |Type |Description|
|---          |---   |---   |
|print  |boolean |Print the exported pdf.|
|accept |string  |Get the details of a particular invoice in formats such as json/ pdf/ html. Default format is json.Allowed Values: `json`, `pdf` and `html`|